### PR TITLE
t/07_stack.t - isn't is deprecated, use isnt instead

### DIFF
--- a/t/07_stack.t
+++ b/t/07_stack.t
@@ -17,6 +17,6 @@ use Data::Clone;
 
 my $before = bless [], Bar::;
 my $after  = clone($before);
-isn't $after, $before, 'stack reallocation during callback';
+isnt $after, $before, 'stack reallocation during callback';
 
 done_testing;


### PR DESCRIPTION
As of 5.37.8 use of apostrophe for a package separator is deprecated, and in 5.40 it will be removed entirely. Switch to isnt() instead of isn't().